### PR TITLE
POS-31: Fix transactions for open item

### DIFF
--- a/src/components/cart/ShoppingCart.vue
+++ b/src/components/cart/ShoppingCart.vue
@@ -52,7 +52,7 @@ async function onTransactionComplete() {
 	const cartItems = cartArray.value.map((item) => {
 		const ret: BaseTransactionItem = {
 			transaction_id: transactionId,
-			product_id: item.id,
+			product_id: item.name === "OPEN ITEM" || !item.barcode ? null : item.id,
 			item_name: item.name,
 			item_price_at_sale: item.price,
 			quantity: item.quantity,

--- a/src/components/cart/ShoppingCart.vue
+++ b/src/components/cart/ShoppingCart.vue
@@ -48,6 +48,7 @@ function onItemSelect(itemId: number) {
 }
 
 async function onTransactionComplete() {
+	if (!cart.value.size) return; // TODO: sonnar no item in cart error
 	const transactionId = await create(total.value);
 	const cartItems = cartArray.value.map((item) => {
 		const ret: BaseTransactionItem = {

--- a/src/composables/cart.ts
+++ b/src/composables/cart.ts
@@ -43,7 +43,10 @@ function useCart() {
 	function removeFromCart(itemId: number) {
 		cart.value.delete(itemId);
 		calculateTotal();
-		if (selectedItemId.value === itemId) selectedItemId.value = null;
+		if (selectedItemId.value === itemId) {
+			selectedItemId.value = null;
+			selectedItem.value = undefined;
+		}
 	}
 
 	function storePreviousCart(transactionId: number) {
@@ -55,6 +58,7 @@ function useCart() {
 		cart.value.clear();
 		total.value = 0;
 		selectedItemId.value = null;
+		selectedItem.value = undefined;
 	}
 
 	function calculateTotal() {
@@ -65,6 +69,7 @@ function useCart() {
 	function selectItem(itemId: number) {
 		selectedItemId.value = selectedItemId.value === itemId ? null : itemId;
 		if (selectedItemId.value) selectedItem.value = cart.value.get(selectedItemId.value);
+		else selectedItem.value = undefined;
 	}
 
 	function editItemInCart(item: Item) {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -67,6 +67,7 @@ onKeyStroke((e) => {
 		case "Insert":
 		case "Delete":
 		case "Backspace":
+		case "Super":
 			e.preventDefault();
 			break;
 		default:


### PR DESCRIPTION
- Id for OPEN ITEM in transaction_items db set to NULL when transaction completes
- Prevent user from completing transaction if no item in cart
- Add Super to list of keystrokes to ignore for linux system
- Fix issue with OptionsAction being enabled even when cart is cleared or item is unselected